### PR TITLE
Fixes Issue #9 - /guilds/:guild_id/members

### DIFF
--- a/docs/reference/guilds/members.rst
+++ b/docs/reference/guilds/members.rst
@@ -1,42 +1,6 @@
 |stub| Members
 ==============
 
-Get Members
------------
-
-Request
-~~~~~~~
-
-.. code-block:: http
-
-    GET https://discordapp.com/api/guilds/:id/members
-
-Response
-~~~~~~~~
-
-An array of objects. Below is an example of a response with one member.
-
-.. code-block:: json
-
-    [
-        {
-            "joined_at": "2015-10-10T10:10:10.100000+00:00",
-            "deaf": false,
-            "user": {
-                "username": "Some User",
-                "discriminator": "1234",
-                "id": "111222333444555666",
-                "avatar": null
-            },
-            "roles": [
-                "111222333444555666"
-            ],
-            "mute": false
-        }
-    ]
-
-
-
 Edit Member
 -----------
 


### PR DESCRIPTION
This endpoint is being removed from the Discord API due to it not being used by the official client.
