### PR TITLE
Fix the Message Delete Event name

### DIFF
--- a/docs/reference/channels/messages.rst
+++ b/docs/reference/channels/messages.rst
@@ -160,7 +160,7 @@ A message was deleted in one of the channels you have read access to.
 .. code-block:: json
 
     {
-        "t": "MESSAGE_UPDATE",
+        "t": "MESSAGE_DELETE",
         "s": 1,
         "op": 0,
         "d": {


### PR DESCRIPTION
Fix the Message Delete Event name to actually be MESSAGE_DELETE instead of MESSAGE_UPDATE
